### PR TITLE
Release version 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-02-24
+
+### Added
+
+- SIMD-accelerated JSON escaping via vectorized character scanning.
+
+### Fixed
+
+- Time format help text and error messages now mark values as examples (`e.g.`) to avoid implying they are the only accepted formats.
+
+### Performance
+
+- Binary search for entry retrieval in the engine, replacing linear scans.
+- SSTable reader reuses its internal data buffer across reads instead of reallocating.
+
 ## [1.0.0] - 2026-02-20
 
 ### Added
@@ -29,5 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `lib-kifa` crate for embedding the storage engine directly in Rust applications.
 - Web documentation site at [xosnrdev.github.io/kifa](https://xosnrdev.github.io/kifa/).
 
-[Unreleased]: https://github.com/xosnrdev/kifa/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/xosnrdev/kifa/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/xosnrdev/kifa/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/xosnrdev/kifa/releases/tag/v1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "kifa"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "lib-kifa"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "crc32fast",
  "criterion",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "simd"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ resolver = "3"
 members = [".", "lib-kifa", "simd"]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 authors = ["Success Kingsley <xosnrdev@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/docs/src/content/docs/reference/changelog.mdx
+++ b/docs/src/content/docs/reference/changelog.mdx
@@ -14,6 +14,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   them before the next release.
 </Aside>
 
+## [1.0.1] - 2026-02-24
+
+[GitHub Release](https://github.com/xosnrdev/kifa/releases/tag/v1.0.1)
+
+### Added
+
+- SIMD-accelerated JSON escaping via vectorized character scanning.
+
+### Fixed
+
+- Time format help text and error messages now mark values as examples (`e.g.`) to avoid implying they are the only accepted formats.
+
+### Performance
+
+- Binary search for entry retrieval in the engine, replacing linear scans.
+- SSTable reader reuses its internal data buffer across reads instead of reallocating.
+
 ## [1.0.0] - 2026-02-20
 
 [GitHub Release](https://github.com/xosnrdev/kifa/releases/tag/v1.0.0)


### PR DESCRIPTION
## Summary

Release version 1.0.1 with updates to the changelog and versioning.

## Core Components

Updated version numbers for the `kifa`, `lib-kifa`, and `simd` packages.

## Platform Support

None

## Helpers

None

## Tests

None

