### PR TITLE
Fix compaction test timing

### DIFF
--- a/lib-kifa/src/engine.rs
+++ b/lib-kifa/src/engine.rs
@@ -856,12 +856,8 @@ fn compaction_loop(
         }
 
         let mut triggered = lock.lock().unwrap_or_else(sync::PoisonError::into_inner);
-        // Checks the flag before blocking so a notify that arrived between the last
-        // drop(triggered) and this lock.lock() is not lost.
-        if !*triggered {
-            let result = cvar.wait_timeout(triggered, COMPACTION_POLL_INTERVAL);
-            triggered = result.unwrap_or_else(sync::PoisonError::into_inner).0;
-        }
+        let result = cvar.wait_timeout(triggered, COMPACTION_POLL_INTERVAL);
+        triggered = result.unwrap_or_else(sync::PoisonError::into_inner).0;
         // Resets and releases the lock so new triggers can arrive while compaction runs.
         *triggered = false;
         drop(triggered);

--- a/lib-kifa/tests/integration.rs
+++ b/lib-kifa/tests/integration.rs
@@ -372,9 +372,13 @@ fn test_background_compaction_triggers_on_threshold() {
         engine.flush().unwrap();
     }
 
-    thread::sleep(time::Duration::from_millis(200));
-
-    assert!(engine.sstable_count() < 4);
+    for _ in 0..100 {
+        if engine.sstable_count() < 4 {
+            return;
+        }
+        thread::sleep(time::Duration::from_millis(50));
+    }
+    panic!("compaction did not reduce sstable count below 4 within 5s");
 }
 
 #[test]
@@ -460,7 +464,11 @@ fn test_compaction_skipped_in_emergency() {
 
     engine.set_flush_mode(FlushMode::Normal);
 
-    thread::sleep(time::Duration::from_millis(200));
-
-    assert!(engine.sstable_count() < 4);
+    for _ in 0..100 {
+        if engine.sstable_count() < 4 {
+            return;
+        }
+        thread::sleep(time::Duration::from_millis(50));
+    }
+    panic!("compaction did not reduce sstable count below 4 within 5s");
 }


### PR DESCRIPTION
## Summary

- Reverts commit 579bd14 ("prevent lost notifications in compaction loop"). The flaky `test_compaction_skipped_in_emergency` failure was not a lost-notification race; the compaction thread wakes up fine, it just can't finish I/O within the 200ms fixed sleep on slow CI.
- Replaces the fixed 200ms sleep in `test_background_compaction_triggers_on_threshold` and `test_compaction_skipped_in_emergency` with a bounded polling loop (100 iterations x 50ms = 5s ceiling).

## Core Components

None

## Platform Support

None

## Helpers

None

## Tests

- `test_background_compaction_triggers_on_threshold`: polls `sstable_count() < 4` instead of sleeping 200ms
- `test_compaction_skipped_in_emergency`: same polling pattern after switching from Emergency to Normal mode
